### PR TITLE
Authenticate from private network

### DIFF
--- a/adapter.ts
+++ b/adapter.ts
@@ -13,6 +13,7 @@ import {
   KEYCLOAK_CLIENT_ID,
   KEYCLOAK_MODE,
   KEYCLOAK_ORIGIN,
+  KEYCLOAK_AUTHORIZATION_ENDPOINT,
   KEYCLOAK_REALM,
   PORT,
 } from "./config.ts";
@@ -240,7 +241,7 @@ function oidcRedirectForCode(req: Request, prompt: string): Response {
   const bundle = `path=${encodeURIComponent(path)}` +
     `&search=${encodeURIComponent(search)}` +
     `&hash=${encodeURIComponent(hash)}`;
-  const target = `${KEYCLOAK_ORIGIN}/realms/${KEYCLOAK_REALM}` +
+  const target = `${KEYCLOAK_AUTHORIZATION_ENDPOINT}/realms/${KEYCLOAK_REALM}` +
     `/protocol/openid-connect/auth?client_id=${KEYCLOAK_CLIENT_ID}` +
     `&response_mode=${KEYCLOAK_MODE}&response_type=code&scope=openid` +
     `&prompt=${prompt}&redirect_uri=https://${host}/static/oidc-adapter.html` +

--- a/adapter.ts
+++ b/adapter.ts
@@ -140,7 +140,11 @@ async function getToken(
     if (!token) throw ("cannot get Keycloak token");
 
     return token;
-  } catch {
+  } catch (error) {
+    console.log('Error during fetch operation:', error);
+    if (DEBUG) console.log(`fetching: {url}`);
+    if (DEBUG) console.log(`headers: \n{headers}`);
+    if (DEBUG) console.log(`body: \n{data}`);
     return undefined;
   }
 }
@@ -197,7 +201,10 @@ async function tokenize(req: Request): Promise<Response> {
 
   // get the access token from Keycloak if the short-term auth code is valid
   const token = await getToken(host, code, path, search, hash);
-  if (!token) return unauthorized();
+  if (!token) {
+      if (DEBUG) console.log(`Could not get Keycloak's access token`);
+      return unauthorized();
+  }
 
   // get the user info from Keycloak by using the access token
   const userInfo = await getUserInfo(token);

--- a/adapter.ts
+++ b/adapter.ts
@@ -143,9 +143,9 @@ async function getToken(
     return token;
   } catch (error) {
     console.log('Error during fetch operation:', error);
-    if (DEBUG) console.log(`fetching: {url}`);
-    if (DEBUG) console.log(`headers: \n{headers}`);
-    if (DEBUG) console.log(`body: \n{data}`);
+    if (DEBUG) console.log(`fetching: ${url}`);
+    if (DEBUG) console.log(`headers: \n${headers}`);
+    if (DEBUG) console.log(`body: \n${data}`);
     return undefined;
   }
 }

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,8 @@
 // keycloak
 export const KEYCLOAK_ORIGIN = Deno.env.get("KEYCLOAK_ORIGIN") ||
   "https://ucs-sso-ng.mydomain.corp";
+export const KEYCLOAK_AUTHORIZATION_ENDPOINT = Deno.env.get("KEYCLOAK_AUTHORIZATION_ENDPOINT") ||
+  KEYCLOAK_ORIGIN;
 export const KEYCLOAK_REALM = Deno.env.get("KEYCLOAK_REALM") || "ucs";
 export const KEYCLOAK_CLIENT_ID = Deno.env.get("KEYCLOAK_CLIENT_ID") || "jitsi";
 export const KEYCLOAK_MODE = Deno.env.get("KEYCLOAK_MODE") || "query";

--- a/docs/setup-docker.md
+++ b/docs/setup-docker.md
@@ -30,10 +30,13 @@ docker run -d \
   -e JWT_APP_ID=myappid \
   -e JWT_APP_SECRET=myappsecret \
   -e ALLOW_UNSECURE_CERT=true \
+  [-e KEYCLOAK_AUTHORIZATION_ENDPOINT=https://ucs-sso-ng.mykeycloak.tld \]
   ghcr.io/nordeck/jitsi-keycloak-adapter
 ```
 
 `KEYCLOAK_ORIGIN` must be resolvable and accessible for the container.
+
+`KEYCLOAK_AUTHORIZATION_ENDPOINT` must be resolvable and accessible for the user's browser. Defaults to `KEYCLOAK_ORIGIN`.
 
 `JWT_APP_ID` and `JWT_APP_SECRET` must be the same for both `keycloak-adapter`
 and `jitsi`.


### PR DESCRIPTION
implementing a fix for #15 

Added a new environment variable, `KEYCLOAK_AUTHORIZATION_ENDPOINT` describing the public facing endpoint (defaulting to `KEYCLOAK_ORIGIN` for backward compatibility), used to redirect the user to the public URL for keycloak when `KEYCLOAK_ORIGIN` is accessible by the containers but not by the user.


**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
